### PR TITLE
chore: update Claude commands - enhance branch cleanup with main sync

### DIFF
--- a/.claude/commands/clean_branch_and_sync_main.md
+++ b/.claude/commands/clean_branch_and_sync_main.md
@@ -3,3 +3,4 @@
 1. `git branch`で現在のブランチを確認
 2. 現在のブランチがmainブランチでない場合はmainブランチに切り替える
 3. `git branch -d feature/description-of-change`でmainブランチ以外のブランチを削除する。エラーが出た場合はそのブランチはマージされていない可能性があるので削除しなくて良い。
+4. `git pull`を実行してmainブランチを最新の状態にする

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,3 +108,7 @@ Centralized layout pattern with unified routing:
   - Promise-based async API for all data access functions
   - Shared ArticleList component for consistent UI rendering
 - Data access functions: `getArticles(locale, type)`, `getBlogPosts(locale)`, `getNewsItems(locale)` (all async)
+
+### Claude Commands
+
+- `/clean_branch` - Enhanced branch cleanup command that also syncs main branch with remote after cleaning up feature branches


### PR DESCRIPTION
## Why
Enhanced the Claude branch cleanup command to include main branch synchronization for better workflow efficiency.

## What & How
- Renamed `clean_branch.md` to `clean_branch_and_sync_main.md`
- Added step 4 to run `git pull` after branch cleanup to sync main with remote
- Updated CLAUDE.md to document the enhanced command functionality

## Note
This improves the git workflow by ensuring the main branch is always up-to-date after cleaning up feature branches, preventing potential conflicts in future development.

🤖 Generated with [Claude Code](https://claude.ai/code)