### PR TITLE
docs: fix trailing whitespace in CLAUDE.md documentation section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Centralized layout pattern with unified routing:
 
 - **docs/plan.md** - Comprehensive implementation plan with current status analysis and phased approach
 - **docs/todo.md** - Simplified priority task list for immediate actions
-- **docs/requirement.md** - Updated requirements document 
+- **docs/requirement.md** - Updated requirements document
 - **docs/adr/** - Architecture Decision Records for technical choices
 
 ### Claude Commands


### PR DESCRIPTION
## Why
The CLAUDE.md file had trailing whitespace in the Project Documentation section that needed to be cleaned up for consistent formatting and code quality.

## What&How
- Removed trailing whitespace from the requirements document line in CLAUDE.md
- This ensures consistent formatting across the documentation
- The change was detected and automatically handled by the linting process

## Note
This is a minor formatting fix that improves code quality and consistency. No functional changes were made.

🤖 Generated with [Claude Code](https://claude.ai/code)