### PR TITLE
docs: update lint commands to include root markdown files

### DIFF
--- a/.claude/commands/git.md
+++ b/.claude/commands/git.md
@@ -4,7 +4,7 @@ NOTE: 変更が存在しないと思った場合も必ず`git add -A`を実行�
 
 1. `git branch` で現在のブランチを確認し、mainブランチでないことを確認
 2. mainブランチの場合は `git checkout -b feature/description-of-change` で新しいフィーチャーブランチを作成
-3. lintチェックを実行するために `pnpm run lint` を実行。もしエラーが出た場合は修正してから次のステップに進むこと。自動修正可能なエラーは `pnpm run lint:fix` を使用して修正すること。
+3. lintチェックを実行するために `cd frontend && pnpm run lint && cd .. && pnpm dlx markdownlint-cli2 "**/*.md" "!frontend/**/*.md" "!node_modules/**/*.md" "!frontend/node_modules/**/*.md"` を実行。もしエラーが出た場合は修正してから次のステップに進むこと。自動修正可能なエラーは `cd frontend && pnpm run lint:fix && cd .. && pnpm dlx markdownlint-cli2 --fix "**/*.md" "!frontend/**/*.md" "!node_modules/**/*.md" "!frontend/node_modules/**/*.md"` を使用して修正すること。
 4. `git diff` で変更内容を確認
 5. 変更内容を反映するためにCLAUDE.mdを更新すること。CLAUDE.mdはプロジェクトの重要なドキュメントであり、変更内容を正確に記録する必要がある。
 6. `git add -A` で全変更をステージング。必ず`git add -A` で全ての変更をステージングすること。絶対に個別にファイルをステージングしないこと。

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -23,13 +23,13 @@
 ### 基本的なリンティング
 
 ```bash
-cd frontend && pnpm run lint
+cd frontend && pnpm run lint && cd .. && pnpm dlx markdownlint-cli2 "**/*.md" "!frontend/**/*.md" "!node_modules/**/*.md" "!frontend/node_modules/**/*.md"
 ```
 
 ### 自動修正を含むリンティング
 
 ```bash
-cd frontend && pnpm run lint:fix
+cd frontend && pnpm run lint:fix && cd .. && pnpm dlx markdownlint-cli2 --fix "**/*.md" "!frontend/**/*.md" "!node_modules/**/*.md" "!frontend/node_modules/**/*.md"
 ```
 
 ## 注意事項

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "MD013": {
+      "line_length": 400,
+      "code_blocks": false,
+      "tables": false,
+      "headings": false
+    }
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "markdownlint.config": {
+    "MD013": {
+      "line_length": 400,
+      "code_blocks": false,
+      "tables": false,
+      "headings": false
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ This is a monorepo with the main application in the `frontend/` directory. The p
 - `cd frontend && pnpm run dev` - Start development server on <http://localhost:3000>
 - `cd frontend && pnpm run build` - Build production application
 - `cd frontend && pnpm run start` - Start production server
-- `cd frontend && pnpm run lint` - Run ESLint, markdownlint, and prettier checks
-- `cd frontend && pnpm run lint:fix` - Run linting with auto-fix (ESLint, markdownlint, prettier)
+- `cd frontend && pnpm run lint && cd .. && pnpm dlx markdownlint-cli2 "**/*.md" "!frontend/**/*.md" "!node_modules/**/*.md" "!frontend/node_modules/**/*.md"` - Run ESLint, markdownlint, and prettier checks for frontend + root markdown files
+- `cd frontend && pnpm run lint:fix && cd .. && pnpm dlx markdownlint-cli2 --fix "**/*.md" "!frontend/**/*.md" "!node_modules/**/*.md" "!frontend/node_modules/**/*.md"` - Run linting with auto-fix for frontend + root markdown files
 - `cd frontend && pnpm run type-check` - Run TypeScript type checking
 
 ## Architecture Overview


### PR DESCRIPTION
## Why
The current lint commands only covered frontend files, but the project has markdown files in the root directory that also need to be linted. This update ensures comprehensive linting coverage across the entire project.

## What&How
- Updated `.claude/commands/git.md` to include markdownlint command for root markdown files in the lint step
- Updated `.claude/commands/lint.md` to include markdownlint command for root markdown files
- Updated `CLAUDE.md` development commands to include markdownlint for root markdown files
- Added `.markdownlint-cli2.jsonc` configuration file for proper markdownlint setup
- Added `.vscode/settings.json` for consistent editor configuration

The new lint commands now run both frontend ESLint/Prettier and root markdown file linting in a single command chain.

## Note
This change improves the project's code quality by ensuring all markdown files are consistently formatted and follow linting rules. The commands are designed to work from the project root directory and exclude node_modules and frontend markdown files to avoid conflicts.

🤖 Generated with [Claude Code](https://claude.ai/code)