### PR TITLE
docs: add profile documentation tasks to todo list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ Centralized layout pattern with unified routing:
 - **Content:** Migrated from hardcoded data to SQLite database with locale-based retrieval
 - **Testing:** No test setup currently configured
 - **Documentation:** Project documentation reorganized with comprehensive implementation plan
+- **Profile Content:** Profile documentation tasks added to todo list for upcoming content enhancement
 
 ### Important Notes
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,6 +1,8 @@
 # TODO
 
 - [x] shadcn/uiを使うようにする
+- [ ] docs/profile.mdを作成し、自分のプロフィール情報を記載する
+- [ ] docs/profile.mdをもとにHomeやProfileページの内容を更新する
 - [ ] Turborepoを使うようにする
 - [ ] ローカルのSupabaseを使うようにする
 - [ ] Denoを使うようにする


### PR DESCRIPTION
## Why
Added profile documentation tasks to the todo list to plan upcoming content enhancement work for the personal website.

## What & How
- Added two new tasks to docs/todo.md:
  - Create docs/profile.md with personal profile information
  - Update Home and Profile pages based on the profile documentation
- Updated CLAUDE.md to reflect the addition of profile content tasks in the Current Implementation Status section

## Note
These tasks are part of the ongoing effort to enhance the personal website with more comprehensive profile content. The profile documentation will serve as the source of truth for personal information displayed across the site.