### PR TITLE
fix: migrate from @next/font to built-in next/font

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,3 +150,4 @@ Centralized layout pattern with unified routing:
 - **Content Width**: Increased max-width from max-w-4xl to max-w-6xl across all pages for better content display
 - **Open Badge Integration**: Added SecHack365 badge image display with external link to verification page
 - **Database Management**: Excluded database files from git tracking by adding `/data/`, `*.db`, `*.db-shm`, `*.db-wal` to .gitignore for proper development workflow
+- **Next.js Font Migration**: Migrated from deprecated `@next/font` package to built-in `next/font` for Next.js 14 compatibility

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -3,6 +3,7 @@
 - [x] shadcn/uiを使うようにする
 - [x] docs/profile.mdを作成し、自分のプロフィール情報を記載する
 - [x] docs/profile.mdをもとにHomeやProfileページの内容を更新する
+- [ ] prdブランチを作る（デプロイ用）
 - [ ] Turborepoを使うようにする
 - [ ] ローカルのSupabaseを使うようにする
 - [ ] Denoは使わないようにする

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.7.2",
-    "@next/font": "^14.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@t3-oss/env-nextjs": "^0.10.1",
     "@tanstack/react-query": "^5.51.23",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -10,9 +10,6 @@ importers:
       "@auth/drizzle-adapter":
         specifier: ^1.7.2
         version: 1.10.0
-      "@next/font":
-        specifier: ^14.2.5
-        version: 14.2.15(next@14.2.30(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       "@radix-ui/react-slot":
         specifier: ^1.2.3
         version: 1.2.3(@types/react@18.3.23)(react@18.3.1)
@@ -702,14 +699,6 @@ packages:
       {
         integrity: sha512-mvVsMIutMxQ4NGZEMZ1kiBNc+la8Xmlk30bKUmCPQz2eFkmsLv54Mha8QZarMaCtSPkkFA1TMD+FIZk0l/PpzA==,
       }
-
-  "@next/font@14.2.15":
-    resolution:
-      {
-        integrity: sha512-QopYhBmCDDrNDynbi+ZD1hDZXmQXVFo7TmAFp4DQgO/kogz1OLbQ92hPigJbj572eZ3GaaVxNIyYVn3/eAsehg==,
-      }
-    peerDependencies:
-      next: "*"
 
   "@next/swc-darwin-arm64@14.2.30":
     resolution:
@@ -4797,10 +4786,6 @@ snapshots:
   "@next/eslint-plugin-next@14.2.30":
     dependencies:
       glob: 10.3.10
-
-  "@next/font@14.2.15(next@14.2.30(react-dom@18.3.1(react@18.3.1))(react@18.3.1))":
-    dependencies:
-      next: 14.2.30(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   "@next/swc-darwin-arm64@14.2.30":
     optional: true


### PR DESCRIPTION
## Why
Next.js 14 recommends using the built-in `next/font` instead of the deprecated `@next/font` package. The deprecated package will be removed in future versions.

## What&How
- Ran `pnpm dlx @next/codemod@latest built-in-next-font .` to automatically migrate font imports
- Removed `@next/font` dependency from package.json
- Updated CLAUDE.md documentation with migration notes

## Note
The migration was performed using the official Next.js codemod tool. No manual code changes were required as the codebase already used the built-in font functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)