### PR TITLE
fix: update pr-cleanup command to sync main before branch cleanup

### DIFF
--- a/.claude/commands/pr-cleanup.md
+++ b/.claude/commands/pr-cleanup.md
@@ -2,5 +2,5 @@
 
 1. `git branch`で現在のブランチを確認
 2. 現在のブランチがmainブランチでない場合はmainブランチに切り替える
-3. `git branch -d feature/description-of-change`でmainブランチ以外のブランチを削除する。エラーが出た場合はそのブランチはマージされていない可能性があるので削除しなくて良い。
-4. `git pull`を実行してmainブランチを最新の状態にする
+3. `git pull`を実行してmainブランチを最新の状態にする
+4. `git branch -d feature/description-of-change`でmainブランチ以外のブランチを削除する。エラーが出た場合はそのブランチはマージされていない可能性があるので削除しなくて良い。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Centralized layout pattern with unified routing:
 
 ### Claude Commands
 
-- `/pr-cleanup` - Enhanced branch cleanup command that also syncs main branch with remote after cleaning up feature branches
+- `/pr-cleanup` - Enhanced branch cleanup command that syncs main branch with remote before cleaning up feature branches
 - `/pr-fix` - Review comment-based PR modification workflow
 - `/pr-push` - Complete PR creation workflow including branch checkout, commit, push, and PR creation
 
@@ -151,3 +151,4 @@ Centralized layout pattern with unified routing:
 - **Open Badge Integration**: Added SecHack365 badge image display with external link to verification page
 - **Database Management**: Excluded database files from git tracking by adding `/data/`, `*.db`, `*.db-shm`, `*.db-wal` to .gitignore for proper development workflow
 - **Next.js Font Migration**: Migrated from deprecated `@next/font` package to built-in `next/font` for Next.js 14 compatibility
+- **Claude Commands**: Updated `/pr-cleanup` command to sync main branch with remote before cleaning up feature branches


### PR DESCRIPTION
## Why
The pr-cleanup command was executing `git pull` after attempting to delete feature branches, which could cause issues when the local main branch is behind remote and the feature branch appears unmerged.

## What&How
- Updated `.claude/commands/pr-cleanup.md` to sync main branch with remote before attempting to delete feature branches
- Changed the order of operations: switch to main → pull latest → delete feature branches
- Updated CLAUDE.md documentation to reflect the improved workflow

## Note
This ensures that branch deletion operations are performed against the most up-to-date main branch, preventing false "not fully merged" errors when the feature branch has actually been merged remotely.

🤖 Generated with [Claude Code](https://claude.ai/code)