### PR TITLE
docs: update kube-scheduler terminology to SchedulingCycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,10 @@ Centralized layout pattern with unified routing:
 - どっちかだけ変えるのではなく、日本語版と英語版の両方を同時に変更すること
 - 句読点は日本語版では「、。」を使用し、英語版では「, .」を使用すること
 
+### Project Maintenance Guidelines
+
+- `@docs/profile.md` の内容とサイトのProfileページの内容は常に同期させること
+
 ### Recent Updates (2025-01-09)
 
 - **Profile Page Enhancement**: Added comprehensive profile sections including education, research, OSS contributions, internships, personal development, freelance work, activities, open badges, speaking, and papers based on docs/profile.md
@@ -152,3 +156,7 @@ Centralized layout pattern with unified routing:
 - **Database Management**: Excluded database files from git tracking by adding `/data/`, `*.db`, `*.db-shm`, `*.db-wal` to .gitignore for proper development workflow
 - **Next.js Font Migration**: Migrated from deprecated `@next/font` package to built-in `next/font` for Next.js 14 compatibility
 - **Claude Commands**: Updated `/pr-cleanup` command to sync main branch with remote before cleaning up feature branches
+
+### Recent Updates (2025-01-09 continued)
+
+- **Profile Content Enhancement**: Updated kube-scheduler terminology to be more specific - changed "kube-schedulerの処理の一部を並列化" to "kube-schedulerのSchedulingCycleの一部を並列化" in both Japanese and English versions for technical accuracy

--- a/docs/profile.md
+++ b/docs/profile.md
@@ -15,7 +15,7 @@
 
 これまで５年間、PFN、CyberAgent、DMM、LayerX、GOなど10社以上で、長期インターンやフリーランスで、SREやSWE、MLエンジニアとして実務経験を積んできました。DMMではDMM TVのエンコーディングシステムをクラスタ化するプロジェクトを主導しました。PFN、LayerX、ACES、フリーランスでは、Kubernetesを用いたML/LLM基盤の開発・運用を行なった経験があり、特にML/LLM x Kubernetesの領域の開発に強みを持っています。
 
-また、Kubernetesに対して複数回の継続的なOSSコントリビューションを行なったり、kube-schedulerの処理の一部を並列化することでパフォーマンスを向上させる手法の提案を行うなど、Kubernetesの実装レベルの深い理解を持っています。
+また、Kubernetesに対して複数回の継続的なOSSコントリビューションを行なったり、kube-schedulerのSchedulingCycleの一部を並列化することでパフォーマンスを向上させる手法の提案を行うなど、Kubernetesの実装レベルの深い理解を持っています。
 
 その他にもインターンで開発チームのリーダーとしてプロジェクトを主導したり、実務以外でもSecHack365、42 Tokyo、Interop STM、Wakamonogでの登壇を行うなど、様々な活動に積極的に取り組んできました。
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -3,6 +3,7 @@
 - [x] shadcn/uiを使うようにする
 - [x] docs/profile.mdを作成し、自分のプロフィール情報を記載する
 - [x] docs/profile.mdをもとにHomeやProfileページの内容を更新する
+- [ ] ユーザーの環境に合わせて、言語やダークモードを自動で切り替えるようにする
 - [ ] prdブランチを作る（デプロイ用）
 - [ ] Turborepoを使うようにする
 - [ ] ローカルのSupabaseを使うようにする

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -19,7 +19,7 @@ export const translations = {
     "profile.bio":
       "Over the past five years, I have gained practical experience as an SRE, SWE, and ML engineer through long-term internships and freelance work at more than 10 companies, including PFN, CyberAgent, DMM, LayerX, and GO. At DMM, I led a project to cluster the encoding system for DMM TV. At PFN, LayerX, ACES, and through freelance work, I have experience developing and operating ML/LLM infrastructure using Kubernetes, with particular expertise in ML/LLM x Kubernetes development.",
     "profile.bio2":
-      "I have made multiple continuous OSS contributions to Kubernetes and proposed methods to improve performance by parallelizing parts of the kube-scheduler processing, demonstrating deep implementation-level understanding of Kubernetes.",
+      "I have made multiple continuous OSS contributions to Kubernetes and proposed methods to improve performance by parallelizing parts of the kube-scheduler SchedulingCycle, demonstrating deep implementation-level understanding of Kubernetes.",
     "profile.bio3":
       "Additionally, I have actively engaged in various activities, including leading projects as a development team leader in internships, and participating in SecHack365, 42 Tokyo, Interop STM, and speaking at Wakamonog outside of work.",
     "profile.education": "Education",
@@ -156,7 +156,7 @@ export const translations = {
     "profile.bio":
       "これまで５年間、PFN、CyberAgent、DMM、LayerX、GOなど10社以上で、長期インターンやフリーランスで、SREやSWE、MLエンジニアとして実務経験を積んできました。DMMではDMM TVのエンコーディングシステムをクラスタ化するプロジェクトを主導しました。PFN、LayerX、ACES、フリーランスでは、Kubernetesを用いたML/LLM基盤の開発・運用を行なった経験があり、特にML/LLM x Kubernetesの領域の開発に強みを持っています。",
     "profile.bio2":
-      "また、Kubernetesに対して複数回の継続的なOSSコントリビューションを行なったり、kube-schedulerの処理の一部を並列化することでパフォーマンスを向上させる手法の提案を行うなど、Kubernetesの実装レベルの深い理解を持っています。",
+      "また、Kubernetesに対して複数回の継続的なOSSコントリビューションを行なったり、kube-schedulerのSchedulingCycleの一部を並列化することでパフォーマンスを向上させる手法の提案を行うなど、Kubernetesの実装レベルの深い理解を持っています。",
     "profile.bio3":
       "その他にもインターンで開発チームのリーダーとしてプロジェクトを主導したり、実務以外でもSecHack365、42 Tokyo、Interop STM、Wakamonogでの登壇を行うなど、様々な活動に積極的に取り組んできました。",
     "profile.education": "学歴",


### PR DESCRIPTION
## Why
The profile description mentioned "kube-schedulerの処理の一部を並列化" (parallelizing parts of kube-scheduler processing) but this was too general. For technical accuracy, it should specifically mention the SchedulingCycle component of kube-scheduler.

## What&How
Updated the terminology in both Japanese and English versions:
- **Japanese**: Changed "kube-schedulerの処理の一部を並列化" to "kube-schedulerのSchedulingCycleの一部を並列化"
- **English**: Changed "parallelizing parts of the kube-scheduler processing" to "parallelizing parts of the kube-scheduler SchedulingCycle"

Applied changes to:
- `docs/profile.md` (source documentation)
- `frontend/src/lib/i18n.ts` (both Japanese and English translations)
- `CLAUDE.md` (project documentation update)

## Note
This ensures consistency between the documentation and the profile page content, following the project guideline that `@docs/profile.md` and the Profile page should always stay synchronized.

🤖 Generated with [Claude Code](https://claude.ai/code)