### PR TITLE
docs: add external platform publishing strategy to todo list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,3 +168,4 @@ Centralized layout pattern with unified routing:
   - Kept "Software Engineer" as "ソフトウェアエンジニア"
 - **Todo List Reorganization**: Reorganized and clarified todo items in docs/todo.md for better priority management and clearer technical direction
 - **Infrastructure Updates**: Added Terraform for infrastructure management and updated storage strategy to use Cloudflare R2 for images and tfstate storage
+- **Content Publishing Strategy**: Added todo item for publishing announcements on LinkedIn and X, and blog posts on external platforms like Qiita, Zenn, note, and Medium

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -4,6 +4,7 @@
 - [x] docs/profile.mdを作成し、自分のプロフィール情報を記載する
 - [x] docs/profile.mdをもとにHomeやProfileページの内容を更新する
 - [ ] Denoは使わないようにする
+- [ ] お知らせはLinkedInの投稿やX、ブログはQiita, Zenn, note, Mediumなどに投稿するようにする
 - [ ] Supabase, Verecl, Cloudflare WorkersはTerraformで構築できるみたいなので、Terraformを使うようにする。tfstateはcloudflare r2とかに保存する
 - [ ] ユーザーの環境に合わせて、言語やダークモードを自動で切り替えるようにする
 - [ ] Turborepoを使うようにする


### PR DESCRIPTION
## Why
Added a todo item to formalize the content publishing strategy for announcements and blog posts on external platforms, improving content distribution and reach.

## What & How
- Added todo item for publishing announcements on LinkedIn and X
- Added todo item for publishing blog posts on external platforms (Qiita, Zenn, note, Medium)
- Updated CLAUDE.md to document this content publishing strategy addition

## Note
This change establishes a clearer direction for content distribution strategy, moving away from self-hosted content management toward leveraging established platforms for better reach and engagement.