### PR TITLE
docs: add Claude Code MCP setup instructions and update development roadmap

### DIFF
--- a/docs/MCP_SETUP.md
+++ b/docs/MCP_SETUP.md
@@ -1,0 +1,6 @@
+# MCP Setup
+
+```bash
+claude mcp add context7 -- npx -y @upstash/context7-mcp # https://github.com/upstash/context7
+claude mcp add playwright npx @playwright/mcp@latest  # https://github.com/microsoft/playwright-mcp
+```

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -64,6 +64,7 @@
     - [ ] [imagesorcery-mcp](https://github.com/sunriseapps/imagesorcery-mcp)
     - [ ] [console-ninja](https://github.com/wallabyjs/console-ninja#mcp-server)
     - [ ] [Figma](https://help.figma.com/hc/ja/articles/32132100833559-Dev-Mode-MCPサーバー利用ガイド)
+    - [ ] [serena](https://github.com/oraios/serena)
   - [ ] [devcontainer](https://docs.anthropic.com/ja/docs/claude-code/devcontainer)
   - [ ] [Sniffly](https://github.com/chiphuyen/sniffly)の導入
 - [ ] テスト、CI/CD


### PR DESCRIPTION
## Why
To provide clear setup instructions for Claude Code MCP servers and track additional MCP servers for future development enhancement.

## What & How
- **Added `docs/MCP_SETUP.md`**: Created documentation with setup commands for context7 and playwright MCP servers
- **Updated `docs/TODO.md`**: Added serena MCP server to the development roadmap for future consideration

## Note
These changes improve the development workflow by providing quick reference commands for setting up essential MCP servers, particularly context7 for library documentation access and playwright for browser automation testing.